### PR TITLE
Editorial: Consistency between prototype methods

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -541,12 +541,13 @@ contributors: Google, Ecma International
       </p>
 
       <emu-alg>
-        1. Let _pr_ be the *this* value.
-        1. If Type(_pr_) is not Object or _pr_ does not have an [[InitializedDisplayNames]] internal slot, throw a *TypeError* exception.
+        1. Let _displayNames_ be *this* value.
+        1. If Type(_displayNames_) is not Object, throw a *TypeError* exception.
+        1. If _displayNames_ does not have an [[InitializedDisplayNames]] internal slot, throw a *TypeError* exception.
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
         1. For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
           1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Let _v_ be the value of _displayNames_'s internal slot whose name is the Internal Slot value of the current row.
           1. If _v_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
         1. Return _options_.


### PR DESCRIPTION
This is only an editorial change to apply consistency between the `resolvedOptions` and `of` methods. This also reflects some common convention from other methods.