### PR TITLE
Remove "calendar" should be rm by datetime types

### DIFF
--- a/index.html
+++ b/index.html
@@ -2075,7 +2075,6 @@ li.menu-search-result-term:before {
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value with the <code>"type"</code> given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
       <li>[[Style]] is one of the String values <code>"narrow"</code>, <code>"short"</code>, or <code>"long"</code>, identifying the display names style used.</li>
       <li>[[Type]] is one of the String values <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, or <code>"currency"</code>, identifying the type of the display names requested.</li>
       <li>[[Fallback]] is one of the String values <code>"code"</code>, or <code>"none"</code>, identifying the fallback return when the system does not have the requested display name.</li>

--- a/spec.emu
+++ b/spec.emu
@@ -314,7 +314,6 @@ contributors: Google, Ecma International
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
-      <li>[[Calendar]] is a String value with the `"type"` given in Unicode Technical Standard 35 for the calendar used for formatting.</li>
       <li>[[Style]] is one of the String values `"narrow"`, `"short"`, or `"long"`, identifying the display names style used.</li>
       <li>[[Type]] is one of the String values `"language"`, `"region"`, `"script"`, or `"currency"`, identifying the type of the display names requested.</li>
       <li>[[Fallback]] is one of the String values `"code"`, or `"none"`, identifying the fallback return when the system does not have the requested display name.</li>


### PR DESCRIPTION
Remove the "calendar" from internal slot which should be removed when
we drop "weekday" and "month" types in v1.