### PR TITLE
Clarify language type handling in CanonicalCodeForDisplayNames and fix a typo

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -70,8 +70,8 @@ contributors: Google, Ecma International
       </p>
       <emu-alg>
         1. If _type_ is `"language"`, then
-          1. If _code_ does not matches the `unicode_language_id` production, throw a *RangeError* exceptipon.
-          1. If IsStructurallyValidLanguageTag(_code_) is *false*, throw a *RangeError* exception.
+          1. If _code_ does not matches the `unicode_language_id` production, throw a *RangeError* exception.  (This allows any Unicode CLDR locale identifier that does not contain extensions.)
+          1. If IsStructurallyValidLanguageTag(_code_) is *false*, throw a *RangeError* exception.  (This allows only the Unicode BCP 47 locale identifier subset, excluding backwards compatibility syntax permitted in a Unicode CLDR locale identifier.)
           1. Set _code_ to CanonicalizeUnicodeLocaleId(_code_).
           1. Return _code_.
         1. If _type_ is `"region"`, then


### PR DESCRIPTION
I was confused why we would first require adherence to `unicode_language_id` and then to `IsStructurallyValidLanguageTag` til I grunged through history.

The first restriction excludes language tags that contain extensions, while (temporarily) allowing backwards compatibility syntax.  The second restriction excludes backwards compatibility syntax, and it enforces the usual additional validity restrictions we want ECMA-402 overall to impose, concerning duplicate variants and the like.

This seems like the sort of thing that's worth either a "NOTE: ..." after each step (something that ECMA-262 has occasionally done), or a parenthetical sentence at end of each step to explain it (something that I've found precedent for in ECMA-402).  To avoid disturbing step numbers, I took the latter tack.

Also, in passing, I fixed a typo in the first of these two steps.